### PR TITLE
fix a flaky test

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -34,7 +34,11 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Duplicate of {@link FlattenSpecParquetInputTest} but for {@link ParquetReader} instead of Hadoop
@@ -42,10 +46,10 @@ import java.util.List;
 public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
 {
   private static final String FLAT_JSON = "{\n"
-                                          + "  \"listDim\" : [ \"listDim1v1\", \"listDim1v2\" ],\n"
-                                          + "  \"dim3\" : 1,\n"
-                                          + "  \"dim2\" : \"d2v1\",\n"
                                           + "  \"dim1\" : \"d1v1\",\n"
+                                          + "  \"dim2\" : \"d2v1\",\n"
+                                          + "  \"dim3\" : 1,\n"
+                                          + "  \"listDim\" : [ \"listDim1v1\", \"listDim1v2\" ],\n"
                                           + "  \"metric1\" : 1,\n"
                                           + "  \"timestamp\" : 1537229880023\n"
                                           + "}";
@@ -205,8 +209,14 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Map<String, Object> map = sampled.get(0).getRawValues();
+    SortedSet<String> keys = new TreeSet<>(map.keySet());
+    Map<String, Object> newMap = new LinkedHashMap<String, Object>();
+    for (String key : keys) { 
+        Object value = map.get(key);
+        newMap.put(key, value);
+     }
+    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(newMap));
   }
 
 


### PR DESCRIPTION
I have resolved a flaky test issue, specifically in the FlattenSpecParquetReaderTest class located at druid/extensions-core/parquet-extensions/src/test/java/org/apache/druid/input.parquet.FlattenSpecParquetReaderTest.java. The root cause of the flakiness was related to an object of type Map within the test, which was being converted to a string. Since the order of elements in a Map is not guaranteed, the resulting string representation could vary between test runs, causing intermittent failures.

To address this problem, I implemented a fix by sorting the keys of the Map object and inserting them into a LinkedHashMap. This choice of data structure ensures the order of elements remains consistent. Subsequently, I passed this sorted LinkedHashMap as a parameter for the subsequent string conversion step.

This fix is significant because it eliminates the uncertainty introduced by the order of elements in the Map object, ensuring that the test consistently passes across different test runs. By doing so, we have improved the reliability and stability of our testing suite.